### PR TITLE
Add genomic sequence augmentation module

### DIFF
--- a/src/augmentation.py
+++ b/src/augmentation.py
@@ -1,0 +1,392 @@
+"""
+Data augmentation for genomic sequences, applied as training-time transforms.
+
+Wraps a base dataset with configurable, on-the-fly augmentations that simulate
+real-world variability in metagenomic surveillance data (variable read lengths,
+sequencing errors, strand ambiguity, partial coverage).
+
+Usage:
+    # As a dataset wrapper
+    base_dataset = SequenceDataset('data/processed/train.csv')
+    augmented = GenomicAugmentationDataset(
+        base_dataset,
+        reverse_complement=True,
+        random_crop=True,
+        sequencing_noise='illumina',
+        n_masking=True,
+        kmer_shuffle=False,
+    )
+    loader = DataLoader(augmented, batch_size=32, shuffle=True)
+
+    # CLI preview
+    python src/augmentation.py --input data/processed/train.csv --preview 10
+"""
+
+import argparse
+import random
+from pathlib import Path
+
+import numpy as np
+
+try:
+    from torch.utils.data import Dataset as _TorchDataset
+except ImportError:
+    _TorchDataset = None
+
+# Complement mapping for DNA bases
+_COMPLEMENT = str.maketrans('ACGTNacgtn', 'TGCANtgcan')
+
+# Valid DNA bases for substitution (uppercase)
+_BASES = ['A', 'C', 'G', 'T']
+
+
+# ---------------------------------------------------------------------------
+# Individual augmentation functions
+# ---------------------------------------------------------------------------
+
+def reverse_complement(sequence):
+    """
+    Return the reverse complement of a DNA sequence.
+
+    DNA is double-stranded, so the virus family is identical regardless of
+    which strand is sequenced. This is a free 2x effective data multiplier.
+    """
+    return sequence.translate(_COMPLEMENT)[::-1]
+
+
+def random_crop(sequence, min_crop_ratio=0.5):
+    """
+    Extract a random contiguous subsequence.
+
+    Simulates variable-length metagenomic fragments so the model learns to
+    classify from partial information.
+
+    Args:
+        sequence: Input DNA sequence string.
+        min_crop_ratio: Minimum fraction of the original length to retain.
+
+    Returns:
+        A random contiguous substring of the input.
+    """
+    seq_len = len(sequence)
+    if seq_len <= 1:
+        return sequence
+
+    min_length = max(1, int(seq_len * min_crop_ratio))
+    crop_length = random.randint(min_length, seq_len)
+    start = random.randint(0, seq_len - crop_length)
+    return sequence[start:start + crop_length]
+
+
+def sequencing_noise(sequence, mode='illumina'):
+    """
+    Introduce simulated sequencing errors.
+
+    Args:
+        sequence: Input DNA sequence string.
+        mode: 'illumina' (~0.1% substitution) or 'nanopore' (~3-5% errors
+              with indels).
+
+    Returns:
+        Sequence with simulated errors.
+    """
+    seq = list(sequence.upper())
+
+    if mode == 'illumina':
+        error_rate = 0.001
+        for i in range(len(seq)):
+            if seq[i] in _BASES and random.random() < error_rate:
+                seq[i] = random.choice([b for b in _BASES if b != seq[i]])
+        return ''.join(seq)
+
+    elif mode == 'nanopore':
+        error_rate = 0.04
+        result = []
+        for base in seq:
+            r = random.random()
+            if r < error_rate * 0.4:
+                # Substitution (~40% of errors)
+                if base in _BASES:
+                    result.append(random.choice([b for b in _BASES if b != base]))
+                else:
+                    result.append(base)
+            elif r < error_rate * 0.7:
+                # Deletion (~30% of errors) — skip this base
+                continue
+            elif r < error_rate:
+                # Insertion (~30% of errors) — add a random base before this one
+                result.append(random.choice(_BASES))
+                result.append(base)
+            else:
+                result.append(base)
+        return ''.join(result)
+
+    else:
+        raise ValueError(f"Unknown noise mode: {mode!r}. Use 'illumina' or 'nanopore'.")
+
+
+def n_masking(sequence, mask_rate=0.02):
+    """
+    Randomly replace bases with 'N' (unknown).
+
+    Simulates low-quality regions in real sequencing data. Conceptually
+    similar to dropout regularization or image occlusion.
+
+    Args:
+        sequence: Input DNA sequence string.
+        mask_rate: Fraction of bases to replace with 'N'.
+
+    Returns:
+        Sequence with random bases replaced by 'N'.
+    """
+    seq = list(sequence)
+    n_to_mask = int(len(seq) * mask_rate)
+    if n_to_mask == 0:
+        return sequence
+
+    positions = random.sample(range(len(seq)), n_to_mask)
+    for pos in positions:
+        seq[pos] = 'N'
+    return ''.join(seq)
+
+
+def kmer_shuffle(sequence, window_size=50, k=3):
+    """
+    Shuffle k-mers within fixed-size windows.
+
+    Destroys fine-grained positional motifs while preserving local nucleotide
+    composition. Forces the model to learn compositional features rather than
+    memorizing exact motif positions.
+
+    Args:
+        sequence: Input DNA sequence string.
+        window_size: Size of each window in bases.
+        k: K-mer size for shuffling.
+
+    Returns:
+        Sequence with k-mers shuffled within each window.
+    """
+    result = []
+    for start in range(0, len(sequence), window_size):
+        window = sequence[start:start + window_size]
+        # Split window into k-mers
+        kmers = [window[i:i + k] for i in range(0, len(window), k)]
+        random.shuffle(kmers)
+        result.append(''.join(kmers))
+    return ''.join(result)
+
+
+# ---------------------------------------------------------------------------
+# Augmentation dataset wrapper
+# ---------------------------------------------------------------------------
+
+# Use torch Dataset as base when available, plain object otherwise
+_Base = _TorchDataset if _TorchDataset is not None else object
+
+
+class GenomicAugmentationDataset(_Base):
+    """
+    Wraps a base dataset and applies configurable sequence augmentations
+    on-the-fly during training.
+
+    The base dataset must return items as dicts with at least a 'sequence' key
+    (str) and a 'label' key (int or str). Any additional keys are passed
+    through unchanged.
+
+    Each augmentation is independently toggled and applied with its own
+    probability on every __getitem__ call, so the same index yields different
+    augmentations across epochs.
+
+    Args:
+        base_dataset: A torch Dataset returning dict items with 'sequence'.
+        reverse_complement: Enable reverse complement (p=0.5).
+        random_crop: Enable random subsequence cropping (p=0.3).
+        min_crop_ratio: Minimum crop length as fraction of original (0.5).
+        sequencing_noise: Noise mode — 'illumina', 'nanopore', or None (p=0.2).
+        n_masking: Enable N-masking (p=0.2).
+        mask_rate: Fraction of bases to mask (0.02).
+        kmer_shuffle: Enable k-mer shuffling within windows (p=0.1).
+        kmer_shuffle_window: Window size for k-mer shuffling (50).
+        kmer_shuffle_k: K-mer size for shuffling (3).
+        p_reverse_complement: Probability for reverse complement.
+        p_random_crop: Probability for random crop.
+        p_sequencing_noise: Probability for sequencing noise.
+        p_n_masking: Probability for N-masking.
+        p_kmer_shuffle: Probability for k-mer shuffling.
+    """
+
+    def __init__(
+        self,
+        base_dataset,
+        reverse_complement=True,
+        random_crop=True,
+        min_crop_ratio=0.5,
+        sequencing_noise=None,
+        n_masking=True,
+        mask_rate=0.02,
+        kmer_shuffle=False,
+        kmer_shuffle_window=50,
+        kmer_shuffle_k=3,
+        p_reverse_complement=0.5,
+        p_random_crop=0.3,
+        p_sequencing_noise=0.2,
+        p_n_masking=0.2,
+        p_kmer_shuffle=0.1,
+    ):
+        self.base_dataset = base_dataset
+        self.do_reverse_complement = reverse_complement
+        self.do_random_crop = random_crop
+        self.min_crop_ratio = min_crop_ratio
+        self.noise_mode = sequencing_noise
+        self.do_n_masking = n_masking
+        self.mask_rate = mask_rate
+        self.do_kmer_shuffle = kmer_shuffle
+        self.kmer_shuffle_window = kmer_shuffle_window
+        self.kmer_shuffle_k = kmer_shuffle_k
+        self.p_reverse_complement = p_reverse_complement
+        self.p_random_crop = p_random_crop
+        self.p_sequencing_noise = p_sequencing_noise
+        self.p_n_masking = p_n_masking
+        self.p_kmer_shuffle = p_kmer_shuffle
+
+    def __len__(self):
+        return len(self.base_dataset)
+
+    def __getitem__(self, idx):
+        item = self.base_dataset[idx]
+        seq = item['sequence']
+        applied = []
+
+        # Order: reverse complement -> crop -> noise -> masking -> shuffle
+        if self.do_reverse_complement and random.random() < self.p_reverse_complement:
+            seq = reverse_complement(seq)
+            applied.append('reverse_complement')
+
+        if self.do_random_crop and random.random() < self.p_random_crop:
+            seq = random_crop(seq, self.min_crop_ratio)
+            applied.append('random_crop')
+
+        if self.noise_mode and random.random() < self.p_sequencing_noise:
+            seq = sequencing_noise(seq, self.noise_mode)
+            applied.append(f'noise_{self.noise_mode}')
+
+        if self.do_n_masking and random.random() < self.p_n_masking:
+            seq = n_masking(seq, self.mask_rate)
+            applied.append('n_masking')
+
+        if self.do_kmer_shuffle and random.random() < self.p_kmer_shuffle:
+            seq = kmer_shuffle(seq, self.kmer_shuffle_window, self.kmer_shuffle_k)
+            applied.append('kmer_shuffle')
+
+        result = dict(item)
+        result['sequence'] = seq
+        result['augmentations'] = applied
+        return result
+
+
+# ---------------------------------------------------------------------------
+# CLI preview
+# ---------------------------------------------------------------------------
+
+def _load_preview_dataset(input_path):
+    """Load a CSV file as a simple list-of-dicts dataset for preview."""
+    import pandas as pd
+
+    df = pd.read_csv(input_path)
+    if 'sequence' not in df.columns:
+        raise ValueError("CSV must have a 'sequence' column.")
+
+    label_col = 'family' if 'family' in df.columns else 'label'
+    if label_col not in df.columns:
+        raise ValueError("CSV must have a 'family' or 'label' column.")
+
+    records = []
+    for _, row in df.iterrows():
+        records.append({
+            'sequence': str(row['sequence']),
+            'label': str(row[label_col]),
+        })
+    return records
+
+
+class _ListDataset(_Base):
+    """Minimal Dataset wrapper around a list of dicts."""
+    def __init__(self, records):
+        self.records = records
+
+    def __len__(self):
+        return len(self.records)
+
+    def __getitem__(self, idx):
+        return self.records[idx]
+
+
+def preview_augmentations(input_path, n_samples=10, seed=42):
+    """
+    Print original vs augmented sequence pairs for visual validation.
+
+    Args:
+        input_path: Path to a CSV with 'sequence' and 'family'/'label' columns.
+        n_samples: Number of samples to preview.
+        seed: Random seed for reproducibility.
+    """
+    random.seed(seed)
+    np.random.seed(seed)
+
+    records = _load_preview_dataset(input_path)
+    base = _ListDataset(records)
+    augmented = GenomicAugmentationDataset(
+        base,
+        reverse_complement=True,
+        random_crop=True,
+        sequencing_noise='illumina',
+        n_masking=True,
+        kmer_shuffle=True,
+    )
+
+    n_samples = min(n_samples, len(base))
+    indices = random.sample(range(len(base)), n_samples)
+
+    print(f"=== Augmentation Preview ({n_samples} samples) ===\n")
+
+    for i, idx in enumerate(indices, 1):
+        original = base[idx]
+        aug = augmented[idx]
+
+        orig_seq = original['sequence']
+        aug_seq = aug['sequence']
+        transforms = aug['augmentations']
+
+        # Truncate display for readability
+        max_display = 80
+        orig_display = orig_seq[:max_display] + ('...' if len(orig_seq) > max_display else '')
+        aug_display = aug_seq[:max_display] + ('...' if len(aug_seq) > max_display else '')
+
+        print(f"--- Sample {i} (index {idx}) ---")
+        print(f"  Label:       {original['label']}")
+        print(f"  Original:    {orig_display}  (len={len(orig_seq)})")
+        print(f"  Augmented:   {aug_display}  (len={len(aug_seq)})")
+        print(f"  Transforms:  {transforms if transforms else ['none']}")
+        print()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Preview genomic sequence augmentations."
+    )
+    parser.add_argument(
+        '--input', type=str,
+        default='data/processed/train.csv',
+        help='Path to sequences CSV (must have sequence + family/label columns)',
+    )
+    parser.add_argument(
+        '--preview', type=int, default=10,
+        help='Number of samples to preview',
+    )
+    parser.add_argument(
+        '--seed', type=int, default=42,
+        help='Random seed for reproducibility',
+    )
+    args = parser.parse_args()
+
+    preview_augmentations(args.input, n_samples=args.preview, seed=args.seed)

--- a/tests/test_augmentation.py
+++ b/tests/test_augmentation.py
@@ -1,0 +1,393 @@
+"""
+Unit tests for the genomic sequence augmentation module.
+
+Verifies each transform preserves sequence validity (only valid nucleotides + N,
+correct length ranges, label preservation) and that the dataset wrapper applies
+augmentations correctly.
+"""
+
+import random
+import string
+
+import pytest
+
+from src.augmentation import (
+    GenomicAugmentationDataset,
+    kmer_shuffle,
+    n_masking,
+    random_crop,
+    reverse_complement,
+    sequencing_noise,
+)
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+VALID_BASES = set('ACGTNacgtn')
+VALID_BASES_UPPER = set('ACGTN')
+
+# Realistic genomic sequences for testing
+SAMPLE_SEQ = 'ATCGATCGATCGATCGATCGATCGATCGATCG' * 10  # 320 bp
+SHORT_SEQ = 'ATCG'
+LONG_SEQ = 'ACGTACGTACGT' * 500  # 6000 bp
+
+
+def make_random_sequence(length=500, seed=42):
+    """Generate a random DNA sequence."""
+    rng = random.Random(seed)
+    return ''.join(rng.choice('ACGT') for _ in range(length))
+
+
+class MockDataset:
+    """Simple mock dataset for testing the wrapper."""
+
+    def __init__(self, sequences, labels):
+        self.sequences = sequences
+        self.labels = labels
+
+    def __len__(self):
+        return len(self.sequences)
+
+    def __getitem__(self, idx):
+        return {
+            'sequence': self.sequences[idx],
+            'label': self.labels[idx],
+        }
+
+
+@pytest.fixture
+def mock_dataset():
+    seqs = [make_random_sequence(300, seed=i) for i in range(20)]
+    labels = [i % 3 for i in range(20)]
+    return MockDataset(seqs, labels)
+
+
+# ---------------------------------------------------------------------------
+# Tests: reverse_complement
+# ---------------------------------------------------------------------------
+
+class TestReverseComplement:
+    def test_basic_complement(self):
+        assert reverse_complement('AACCGGTT') == 'AACCGGTT'  # palindrome
+
+    def test_simple_sequence(self):
+        assert reverse_complement('AAAA') == 'TTTT'
+        assert reverse_complement('CCCC') == 'GGGG'
+        assert reverse_complement('ATCG') == 'CGAT'
+
+    def test_preserves_length(self):
+        result = reverse_complement(SAMPLE_SEQ)
+        assert len(result) == len(SAMPLE_SEQ)
+
+    def test_double_reverse_is_identity(self):
+        result = reverse_complement(reverse_complement(SAMPLE_SEQ))
+        assert result == SAMPLE_SEQ
+
+    def test_only_valid_bases(self):
+        result = reverse_complement(SAMPLE_SEQ)
+        assert all(c in VALID_BASES for c in result)
+
+    def test_handles_n_bases(self):
+        seq = 'ATCNGATN'
+        result = reverse_complement(seq)
+        assert result == 'NATCNGAT'
+        assert len(result) == len(seq)
+
+    def test_handles_lowercase(self):
+        result = reverse_complement('atcg')
+        assert result == 'cgat'
+
+    def test_empty_string(self):
+        assert reverse_complement('') == ''
+
+    def test_single_base(self):
+        assert reverse_complement('A') == 'T'
+        assert reverse_complement('C') == 'G'
+
+
+# ---------------------------------------------------------------------------
+# Tests: random_crop
+# ---------------------------------------------------------------------------
+
+class TestRandomCrop:
+    def test_output_is_substring(self):
+        result = random_crop(SAMPLE_SEQ, min_crop_ratio=0.5)
+        assert result in SAMPLE_SEQ
+
+    def test_respects_min_crop_ratio(self):
+        min_ratio = 0.5
+        for _ in range(100):
+            result = random_crop(SAMPLE_SEQ, min_crop_ratio=min_ratio)
+            assert len(result) >= int(len(SAMPLE_SEQ) * min_ratio)
+
+    def test_never_exceeds_original_length(self):
+        for _ in range(100):
+            result = random_crop(SAMPLE_SEQ, min_crop_ratio=0.5)
+            assert len(result) <= len(SAMPLE_SEQ)
+
+    def test_full_ratio_returns_original(self):
+        for _ in range(10):
+            result = random_crop(SAMPLE_SEQ, min_crop_ratio=1.0)
+            assert result == SAMPLE_SEQ
+
+    def test_only_valid_bases(self):
+        result = random_crop(SAMPLE_SEQ, min_crop_ratio=0.5)
+        assert all(c in VALID_BASES for c in result)
+
+    def test_short_sequence(self):
+        result = random_crop('A', min_crop_ratio=0.5)
+        assert result == 'A'
+
+    def test_empty_string(self):
+        result = random_crop('', min_crop_ratio=0.5)
+        assert result == ''
+
+
+# ---------------------------------------------------------------------------
+# Tests: sequencing_noise (illumina)
+# ---------------------------------------------------------------------------
+
+class TestSequencingNoiseIllumina:
+    def test_preserves_length(self):
+        result = sequencing_noise(SAMPLE_SEQ, mode='illumina')
+        assert len(result) == len(SAMPLE_SEQ)
+
+    def test_only_valid_bases(self):
+        result = sequencing_noise(SAMPLE_SEQ, mode='illumina')
+        assert all(c in VALID_BASES_UPPER for c in result)
+
+    def test_low_error_rate(self):
+        """Illumina has ~0.1% error rate — most bases unchanged."""
+        seq = make_random_sequence(10000, seed=99)
+        result = sequencing_noise(seq, mode='illumina')
+        mismatches = sum(a != b for a, b in zip(seq, result))
+        # With 0.1% rate on 10k bases, expect ~10 errors. Allow up to 50.
+        assert mismatches < 50
+
+    def test_empty_string(self):
+        assert sequencing_noise('', mode='illumina') == ''
+
+
+# ---------------------------------------------------------------------------
+# Tests: sequencing_noise (nanopore)
+# ---------------------------------------------------------------------------
+
+class TestSequencingNoiseNanopore:
+    def test_only_valid_bases(self):
+        result = sequencing_noise(SAMPLE_SEQ, mode='nanopore')
+        assert all(c in VALID_BASES_UPPER for c in result)
+
+    def test_length_changes_possible(self):
+        """Nanopore mode has indels, so length may change."""
+        lengths = set()
+        for seed in range(50):
+            random.seed(seed)
+            result = sequencing_noise(LONG_SEQ, mode='nanopore')
+            lengths.add(len(result))
+        # With insertions and deletions, we should see length variation
+        assert len(lengths) > 1
+
+    def test_empty_string(self):
+        assert sequencing_noise('', mode='nanopore') == ''
+
+    def test_invalid_mode_raises(self):
+        with pytest.raises(ValueError, match="Unknown noise mode"):
+            sequencing_noise(SAMPLE_SEQ, mode='invalid')
+
+
+# ---------------------------------------------------------------------------
+# Tests: n_masking
+# ---------------------------------------------------------------------------
+
+class TestNMasking:
+    def test_preserves_length(self):
+        result = n_masking(SAMPLE_SEQ, mask_rate=0.05)
+        assert len(result) == len(SAMPLE_SEQ)
+
+    def test_only_valid_bases(self):
+        result = n_masking(SAMPLE_SEQ, mask_rate=0.05)
+        assert all(c in VALID_BASES for c in result)
+
+    def test_introduces_n_bases(self):
+        """With a 10% mask rate on a long sequence, we should see some N's."""
+        seq = make_random_sequence(1000, seed=0)
+        result = n_masking(seq, mask_rate=0.10)
+        n_count = result.count('N')
+        assert n_count > 0
+
+    def test_approximate_mask_rate(self):
+        seq = make_random_sequence(10000, seed=1)
+        result = n_masking(seq, mask_rate=0.05)
+        n_count = result.count('N')
+        # Expect ~500 N's; allow a range
+        assert 300 < n_count < 700
+
+    def test_zero_rate_no_change(self):
+        result = n_masking(SAMPLE_SEQ, mask_rate=0.0)
+        assert result == SAMPLE_SEQ
+
+    def test_empty_string(self):
+        result = n_masking('', mask_rate=0.05)
+        assert result == ''
+
+    def test_short_sequence_zero_masks(self):
+        """A very short sequence with low rate may mask 0 bases."""
+        result = n_masking('AT', mask_rate=0.01)
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests: kmer_shuffle
+# ---------------------------------------------------------------------------
+
+class TestKmerShuffle:
+    def test_preserves_length(self):
+        result = kmer_shuffle(SAMPLE_SEQ, window_size=50, k=3)
+        assert len(result) == len(SAMPLE_SEQ)
+
+    def test_only_valid_bases(self):
+        result = kmer_shuffle(SAMPLE_SEQ, window_size=50, k=3)
+        assert all(c in VALID_BASES for c in result)
+
+    def test_preserves_composition(self):
+        """K-mer shuffle preserves local nucleotide composition."""
+        seq = make_random_sequence(300, seed=5)
+        result = kmer_shuffle(seq, window_size=300, k=3)
+        # Same bases, just reordered
+        assert sorted(result) == sorted(seq)
+
+    def test_empty_string(self):
+        result = kmer_shuffle('', window_size=50, k=3)
+        assert result == ''
+
+    def test_short_sequence(self):
+        result = kmer_shuffle('ACG', window_size=50, k=3)
+        assert result == 'ACG'  # single k-mer, nothing to shuffle
+
+
+# ---------------------------------------------------------------------------
+# Tests: GenomicAugmentationDataset
+# ---------------------------------------------------------------------------
+
+class TestGenomicAugmentationDataset:
+    def test_length_matches_base(self, mock_dataset):
+        aug = GenomicAugmentationDataset(mock_dataset)
+        assert len(aug) == len(mock_dataset)
+
+    def test_label_preserved(self, mock_dataset):
+        aug = GenomicAugmentationDataset(
+            mock_dataset,
+            reverse_complement=True,
+            random_crop=True,
+            sequencing_noise='illumina',
+            n_masking=True,
+            kmer_shuffle=True,
+        )
+        for i in range(len(mock_dataset)):
+            original = mock_dataset[i]
+            augmented = aug[i]
+            assert augmented['label'] == original['label']
+
+    def test_sequence_is_valid(self, mock_dataset):
+        aug = GenomicAugmentationDataset(
+            mock_dataset,
+            reverse_complement=True,
+            random_crop=True,
+            sequencing_noise='illumina',
+            n_masking=True,
+            kmer_shuffle=True,
+        )
+        for i in range(len(mock_dataset)):
+            item = aug[i]
+            assert all(c in VALID_BASES_UPPER for c in item['sequence'])
+
+    def test_augmentations_key_present(self, mock_dataset):
+        aug = GenomicAugmentationDataset(mock_dataset)
+        item = aug[0]
+        assert 'augmentations' in item
+        assert isinstance(item['augmentations'], list)
+
+    def test_no_augmentation_when_all_disabled(self, mock_dataset):
+        aug = GenomicAugmentationDataset(
+            mock_dataset,
+            reverse_complement=False,
+            random_crop=False,
+            sequencing_noise=None,
+            n_masking=False,
+            kmer_shuffle=False,
+        )
+        for i in range(len(mock_dataset)):
+            original = mock_dataset[i]
+            augmented = aug[i]
+            assert augmented['sequence'] == original['sequence']
+            assert augmented['augmentations'] == []
+
+    def test_stochastic_augmentation(self, mock_dataset):
+        """Multiple calls to the same index should sometimes differ."""
+        aug = GenomicAugmentationDataset(
+            mock_dataset,
+            reverse_complement=True,
+            p_reverse_complement=0.5,
+        )
+        results = set()
+        for _ in range(50):
+            item = aug[0]
+            results.add(item['sequence'])
+        # With p=0.5 over 50 draws, we should see both original and RC
+        assert len(results) > 1
+
+    def test_passthrough_extra_keys(self):
+        """Extra keys in base items are preserved."""
+        class ExtraDataset:
+            def __len__(self):
+                return 1
+            def __getitem__(self, idx):
+                return {
+                    'sequence': 'ATCGATCG',
+                    'label': 0,
+                    'id': 'seq_001',
+                    'metadata': {'source': 'ncbi'},
+                }
+
+        aug = GenomicAugmentationDataset(ExtraDataset(), reverse_complement=False)
+        item = aug[0]
+        assert item['id'] == 'seq_001'
+        assert item['metadata'] == {'source': 'ncbi'}
+
+    def test_compose_multiple_augmentations(self, mock_dataset):
+        """Multiple augmentations can be applied to the same sample."""
+        aug = GenomicAugmentationDataset(
+            mock_dataset,
+            reverse_complement=True,
+            random_crop=True,
+            sequencing_noise='illumina',
+            n_masking=True,
+            kmer_shuffle=True,
+            # Set all probabilities to 1.0 so all are applied
+            p_reverse_complement=1.0,
+            p_random_crop=1.0,
+            p_sequencing_noise=1.0,
+            p_n_masking=1.0,
+            p_kmer_shuffle=1.0,
+        )
+        item = aug[0]
+        assert 'reverse_complement' in item['augmentations']
+        assert 'random_crop' in item['augmentations']
+        assert 'noise_illumina' in item['augmentations']
+        assert 'n_masking' in item['augmentations']
+        assert 'kmer_shuffle' in item['augmentations']
+
+    def test_nanopore_noise_mode(self, mock_dataset):
+        aug = GenomicAugmentationDataset(
+            mock_dataset,
+            reverse_complement=False,
+            random_crop=False,
+            sequencing_noise='nanopore',
+            n_masking=False,
+            kmer_shuffle=False,
+            p_sequencing_noise=1.0,
+        )
+        item = aug[0]
+        assert 'noise_nanopore' in item['augmentations']
+        assert all(c in VALID_BASES_UPPER for c in item['sequence'])


### PR DESCRIPTION
## Summary
- Implements `GenomicAugmentationDataset` in `src/augmentation.py` — a PyTorch Dataset wrapper that applies configurable, on-the-fly training-time transforms to genomic sequences (closes #2)
- Five individually toggleable augmentations: reverse complement (p=0.5), random subsequence cropping (p=0.3), simulated sequencing noise with Illumina/Nanopore modes (p=0.2), N-masking (p=0.2), and k-mer shuffling within windows (p=0.1)
- Includes CLI preview mode (`python src/augmentation.py --input data/processed/train.csv --preview 10`) and 45 unit tests verifying transform correctness, valid base output, and label preservation

## Test plan
- [x] All 45 unit tests pass (`pytest tests/test_augmentation.py`)
- [ ] Run CLI preview with real training data after preprocessing (#1) is merged
- [ ] Verify augmented DataLoader integration during model training

🤖 Generated with [Claude Code](https://claude.com/claude-code)