### PR TITLE
Fix deployment issues found during Azure ML testing

### DIFF
--- a/deployment/azure/conda_baseline.yml
+++ b/deployment/azure/conda_baseline.yml
@@ -8,3 +8,4 @@ dependencies:
     - xgboost>=2.0.0
     - numpy
     - inference-schema[numpy-support]
+    - azureml-inference-server-http

--- a/deployment/azure/score.py
+++ b/deployment/azure/score.py
@@ -103,7 +103,7 @@ def _extract_features(sequences, k, vocab, kmer_to_idx):
 # Input validation
 # ============================================================================
 
-_VALID_DNA = re.compile(r"^[ACGTNacgtn]+$")
+_VALID_DNA = re.compile(r"^[ACGTNRYSWKMBDHVacgtnryswkmbdhv]+$")
 
 
 def _validate_sequences(sequences):
@@ -134,7 +134,7 @@ def _validate_sequences(sequences):
         if not _VALID_DNA.match(seq):
             raise ValueError(
                 f"Sequence at index {i} contains invalid characters. "
-                f"Only A, C, G, T, N are allowed."
+                f"Only IUPAC nucleotide codes (A, C, G, T, N, R, Y, etc.) are allowed."
             )
 
 
@@ -153,10 +153,20 @@ def init():
     global _kmer_k, _kmer_vocab, _kmer_to_idx
 
     model_dir = os.getenv("AZUREML_MODEL_DIR", "models/baseline")
+
+    # Azure ML may nest files under a subdirectory (e.g., baseline/)
+    # when registering a directory as a model. Search for the model file.
+    model_path = os.path.join(model_dir, "xgboost_model.json")
+    if not os.path.exists(model_path):
+        for root, _dirs, files in os.walk(model_dir):
+            if "xgboost_model.json" in files:
+                model_dir = root
+                model_path = os.path.join(root, "xgboost_model.json")
+                break
+
     logger.info("Loading model from %s", model_dir)
 
     # Load XGBoost model
-    model_path = os.path.join(model_dir, "xgboost_model.json")
     _booster = xgb.Booster()
     _booster.load_model(model_path)
     logger.info("XGBoost model loaded from %s", model_path)

--- a/deployment/azure/test_endpoint.py
+++ b/deployment/azure/test_endpoint.py
@@ -98,6 +98,11 @@ def test_endpoint(endpoint_url, api_key, sequences, names=None):
 
     elapsed = time.time() - start
 
+    # Azure ML may return a JSON string (score.py returns json.dumps())
+    # so we may need to parse it again
+    if isinstance(result, str):
+        result = json.loads(result)
+
     if "error" in result:
         print(f"Error from endpoint: {result['error']}")
         return

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -273,6 +273,10 @@ class TestValidation:
         with pytest.raises(ValueError, match="invalid characters"):
             score._validate_sequences(["ACGT123"])
 
+    def test_accepts_iupac_codes(self):
+        """IUPAC ambiguity codes should be accepted."""
+        score._validate_sequences(["ACGTRYWSMKHBDVN"])
+
     def test_rejects_non_string(self):
         """Non-string elements should raise ValueError."""
         with pytest.raises(ValueError, match="non-empty string"):


### PR DESCRIPTION
## Summary

- Add `azureml-inference-server-http` to conda environment (required by Azure ML managed endpoints)
- Handle nested model directory structure in score.py (Azure ML puts registered directory models under a subdirectory)
- Accept IUPAC ambiguity codes (R, Y, S, W, K, M, B, D, H, V) in input validation, not just ACGTN
- Handle double-serialized JSON response in test_endpoint.py
- Add IUPAC validation test

These fixes were discovered during live Azure ML deployment testing and were pushed to the PR #22 branch after it had already been merged.

## Test plan

- [x] `pytest tests/test_scoring.py -v` — 26/26 pass
- [x] Live Azure ML deployment tested successfully with these fixes


🤖 Generated with [Claude Code](https://claude.com/claude-code)